### PR TITLE
chore(tooling): Add semantic release and commitizen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+cache:
+  directories:
+    - ~/.npm
+notifications:
+  email: false
+node_js:
+  - '9'
+  - '8'
+after_success:
+  - npm run travis-deploy-once "npm run semantic-release"
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+
 # RUMpelstiltskin
 
 A general utility to collect RUM(Real User Metrics) using the timing and performance APIs
+
+## A note on commits
+
+To ensure commits follow the semantic-release/conventional commit format, you will need to run:
+
+```
+npm run cz
+```
+
+This is in place of the usual `git commit -m 'message'` format.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rumpelstiltskin",
-  "version": "0.0.1",
+  "version": "0.0.0-semantically-released",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1245,6 +1245,12 @@
         "typedarray": "0.0.6"
       }
     },
+    "conventional-commit-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz",
+      "integrity": "sha1-XblXOdbCEqy+e29lahG5QLqmiUY=",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -1298,6 +1304,19 @@
       "dev": true,
       "requires": {
         "array-find-index": "1.0.2"
+      }
+    },
+    "cz-conventional-changelog": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
+      "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
+      "dev": true,
+      "requires": {
+        "conventional-commit-types": "2.2.0",
+        "lodash.map": "4.6.0",
+        "longest": "1.0.1",
+        "right-pad": "1.0.1",
+        "word-wrap": "1.2.3"
       }
     },
     "d": {
@@ -3727,6 +3746,12 @@
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -3766,6 +3791,12 @@
           }
         }
       }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -4946,6 +4977,12 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "right-pad": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+      "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
       "dev": true
     },
     "rimraf": {
@@ -6236,6 +6273,12 @@
       "requires": {
         "isexe": "2.0.0"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,37 +1,43 @@
 {
-  "name": "rumpelstiltskin",
-  "version": "0.0.1",
-  "description": "A general utility to collect RUM(Real User Metrics) using the timing APIs",
-  "main": "index.js",
-  "scripts": {
-    "test": ""
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/schalkneethling/rumpelstiltskin.git"
-  },
-  "keywords": [
-    "utils",
-    "javascript",
-    "rum",
-    "user",
-    "timing"
-  ],
-  "author": "Schalk Neethling",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/schalkneethling/rumpelstiltskin/issues"
-  },
-  "homepage": "https://github.com/schalkneethling/rumpelstiltskin#readme",
-  "devDependencies": {
-    "babel-cli": "6.26.0",
-    "babel-preset-env": "1.7.0",
-    "eslint": "4.19.1",
-    "prettier": "1.12.1",
-    "sass-lint": "1.12.1",
-    "stylelint": "9.2.1"
-  },
-  "calavera": {
-    "commonjs": true
-  }
+    "name": "rumpelstiltskin",
+    "version": "0.0.0-semantically-released",
+    "description":
+        "A general utility to collect RUM(Real User Metrics) using the timing APIs",
+    "main": "index.js",
+    "scripts": {
+        "cz": "git-cz",
+        "test": "",
+        "travis-deploy-once": "travis-deploy-once",
+        "semantic-release": "semantic-release"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/schalkneethling/rumpelstiltskin.git"
+    },
+    "keywords": ["utils", "javascript", "rum", "user", "timing"],
+    "author": "Schalk Neethling",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/schalkneethling/rumpelstiltskin/issues"
+    },
+    "homepage": "https://github.com/schalkneethling/rumpelstiltskin#readme",
+    "devDependencies": {
+        "babel-cli": "6.26.0",
+        "babel-preset-env": "1.7.0",
+        "cz-conventional-changelog": "^2.1.0",
+        "eslint": "4.19.1",
+        "prettier": "1.12.1",
+        "sass-lint": "1.12.1",
+        "semantic-release": "^15.5.0",
+        "stylelint": "9.2.1",
+        "travis-deploy-once": "^5.0.0"
+    },
+    "calavera": {
+        "commonjs": true
+    },
+    "config": {
+        "commitizen": {
+            "path": "./node_modules/cz-conventional-changelog"
+        }
+    }
 }


### PR DESCRIPTION
Add semantic-release and commitizen to automate releases of this repo. This also enforces the conventional changelog convention for commit messages