### PR TITLE
feat(lib): Implements getPerformanceEntries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,21 @@
 
 const rumpelstiltskin = {
     /**
+     * Collects and returns an Array of performance entries. Entries are
+     * either matched by label, entryType, or label and entryType
+     * @param {String} [label] - Optional name for the mark
+     * @param {String} [entryType] - Optional one of Performance.entryType
+     * @returns Array of performance entries matching the specified criteria
+     */
+    getPerformanceEntries: (label, entryType) => {
+        if (label && entryType) {
+            return performance.getEntriesByName(label, entryType);
+        } else if (entryType) {
+            return performance.getEntriesByType(entryType);
+        }
+        return performance.getEntriesByName(label);
+    },
+    /**
      * Calculate and return the difference between
      * PerformanceTiming.domComplete and PerformanceTiming.domLoading
      * NOTE: This focuses on the critical path only. Not when the user first

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,15 @@ const rumpelstiltskin = {
      * @returns Array of performance entries matching the specified criteria
      */
     getPerformanceEntries: (label, entryType) => {
+        /* if both label and entryType is undefined 
+           log an error and return */
+        if (!label && !entryType) {
+            console.error(
+                'No parameters passed. Please pass at least a label or entryType'
+            );
+            return;
+        }
+
         if (label && entryType) {
             return performance.getEntriesByName(label, entryType);
         } else if (entryType) {


### PR DESCRIPTION
Implements the getPerformanceEntries function. This allows you to get entries by label, entryType, or both

Fix #5